### PR TITLE
Fix the spell of field annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ A type level annotation with `lang/ddl` namespace will cause ddl to be emitted f
 - `@lang/ddl type <THE TYPE>.<PARAMETER>` - Overrites the column's datatype with specified value with a parameter. e.g. `@lang/ddl type varchar.50`
 - `@lang/ddl fk <OTHER TYPE>.<FIELD>` - Adds a foreign key constraint
 - `@lang/ddl AUTO_INCREMENT true` - Indicates that column should be auto incremented
-- `@lang/ddl supress _` - Indicates that a column should not be emitted for this field. Useful when e.g. you want to expose a field that is not sourced as a column of a table.
+- `@lang/ddl suppress _` - Indicates that a column should not be emitted for this field. Useful when e.g. you want to expose a field that is not sourced as a column of a table.
 - `@doc "<the comment>"` - renders a comment for the corresponding column
 
 ## Mapping with umlaut built in dsl

--- a/datamodel.umlaut
+++ b/datamodel.umlaut
@@ -16,7 +16,7 @@ type Company {
      @lang/ddl unique _
   }
   philosophy: String {
-     @lang/ddl supress _
+     @lang/ddl suppress _
   }
   address: String {
      @lang/ddl type varchar.50

--- a/src/umlaut/generators/ddl/mysql.clj
+++ b/src/umlaut/generators/ddl/mysql.clj
@@ -38,7 +38,7 @@
 
 (defn map-column-type [field-def umlaut]
   (when-not (seq (some->> (get-in field-def [:field-annotations :others])
-                          (annotations-by-space-key "supress")))
+                          (annotations-by-space-key "suppress")))
     (or (let [type-annot-val (some->> (get-in field-def [:field-annotations :others])
                                       (annotations-by-space-key "type")
                                       first


### PR DESCRIPTION
Is the spell `supress` intentional?
I think it's more user-friendly to use correct spelling `suppress`.